### PR TITLE
refactor(graders): reorder JSON schema to reason before score

### DIFF
--- a/openjudge/graders/agent/action/action_alignment.py
+++ b/openjudge/graders/agent/action/action_alignment.py
@@ -60,8 +60,8 @@ Action: {action}
 <Output Schema>
 Provide your evaluation in the following structured JSON format:
 {{
-    "score": <0.0 or 1.0>,
-    "reason": "<detailed explanation of action-plan alignment and confidence level>"
+    "reason": "<detailed explanation of action-plan alignment and confidence level>",
+    "score": <0.0 or 1.0>
 }}
 </Output Schema>
 JSON:
@@ -108,8 +108,8 @@ ACTION_ALIGNMENT_PROMPT_ZH = textwrap.dedent(
 <输出格式>
 请按以下结构化 JSON 格式提供你的评估：
 {{
-    "score": <0.0 或 1.0>,
-    "reason": "<关于动作-计划对齐的详细解释和置信度水平>"
+    "reason": "<关于动作-计划对齐的详细解释和置信度水平>",
+    "score": <0.0 或 1.0>
 }}
 </输出格式>
 JSON:

--- a/openjudge/graders/agent/memory/memory_accuracy.py
+++ b/openjudge/graders/agent/memory/memory_accuracy.py
@@ -60,8 +60,8 @@ Memory: {memory}
 <Output Schema>
 Provide your evaluation in the following structured JSON format:
 {{
-    "score": <0.0 or 1.0>,
-    "reason": "<detailed explanation of memory accuracy and confidence level>"
+    "reason": "<detailed explanation of memory accuracy and confidence level>",
+    "score": <0.0 or 1.0>
 }}
 </Output Schema>
 JSON:
@@ -108,8 +108,8 @@ MEMORY_ACCURACY_PROMPT_ZH = textwrap.dedent(
 <输出格式>
 请按以下结构化 JSON 格式提供你的评估：
 {{
-    "score": <0.0 或 1.0>,
-    "reason": "<关于记忆准确性的详细解释和置信度水平>"
+    "reason": "<关于记忆准确性的详细解释和置信度水平>",
+    "score": <0.0 或 1.0>
 }}
 </输出格式>
 JSON:

--- a/openjudge/graders/agent/memory/memory_detail_preservation.py
+++ b/openjudge/graders/agent/memory/memory_detail_preservation.py
@@ -60,8 +60,8 @@ Memory: {memory}
 <Output Schema>
 Provide your evaluation in the following structured JSON format:
 {{
-    "score": <0.0 or 1.0>,
-    "reason": "<detailed explanation of detail preservation quality and confidence level>"
+    "reason": "<detailed explanation of detail preservation quality and confidence level>",
+    "score": <0.0 or 1.0>
 }}
 </Output Schema>
 JSON:
@@ -108,8 +108,8 @@ MEMORY_DETAIL_PRESERVATION_PROMPT_ZH = textwrap.dedent(
 <输出格式>
 请按以下结构化 JSON 格式提供你的评估：
 {{
-    "score": <0.0 或 1.0>,
-    "reason": "<关于细节保留质量的详细解释和置信度水平>"
+    "reason": "<关于细节保留质量的详细解释和置信度水平>",
+    "score": <0.0 或 1.0>
 }}
 </输出格式>
 JSON:

--- a/openjudge/graders/agent/memory/memory_retrieval_effectiveness.py
+++ b/openjudge/graders/agent/memory/memory_retrieval_effectiveness.py
@@ -61,8 +61,8 @@ Memory: {memory}
 <Output Schema>
 Provide your evaluation in the following structured JSON format:
 {{
-    "score": <0.0 or 1.0>,
-    "reason": "<detailed explanation of memory retrieval effectiveness and confidence level>"
+    "reason": "<detailed explanation of memory retrieval effectiveness and confidence level>",
+    "score": <0.0 or 1.0>
 }}
 </Output Schema>
 JSON:
@@ -110,8 +110,8 @@ MEMORY_RETRIEVAL_EFFECTIVENESS_PROMPT_ZH = textwrap.dedent(
 <输出格式>
 请按以下结构化 JSON 格式提供你的评估：
 {{
-    "score": <0.0 或 1.0>,
-    "reason": "<关于记忆检索有效性的详细解释和置信度水平>"
+    "reason": "<关于记忆检索有效性的详细解释和置信度水平>",
+    "score": <0.0 或 1.0>
 }}
 </输出格式>
 JSON:

--- a/openjudge/graders/agent/plan/plan_feasibility.py
+++ b/openjudge/graders/agent/plan/plan_feasibility.py
@@ -61,8 +61,8 @@ Memory: {memory}
 <Output Schema>
 Provide your evaluation in the following structured JSON format:
 {{
-    "score": <0.0 or 1.0>,
-    "reason": "<detailed explanation of plan feasibility and confidence level>"
+    "reason": "<detailed explanation of plan feasibility and confidence level>",
+    "score": <0.0 or 1.0>
 }}
 </Output Schema>
 JSON:
@@ -110,8 +110,8 @@ PLAN_FEASIBILITY_PROMPT_ZH = textwrap.dedent(
 <输出格式>
 请按以下结构化 JSON 格式提供你的评估：
 {{
-    "score": <0.0 或 1.0>,
-    "reason": "<关于计划可行性的详细解释和置信度水平>"
+    "reason": "<关于计划可行性的详细解释和置信度水平>",
+    "score": <0.0 或 1.0>
 }}
 </输出格式>
 JSON:

--- a/openjudge/graders/agent/reflection/reflection_accuracy.py
+++ b/openjudge/graders/agent/reflection/reflection_accuracy.py
@@ -60,8 +60,8 @@ Reflection: {reflection}
 <Output Schema>
 Provide your evaluation in the following structured JSON format:
 {{
-    "score": <0.0 or 1.0>,
-    "reason": "<detailed explanation of reflection accuracy and confidence level>"
+    "reason": "<detailed explanation of reflection accuracy and confidence level>",
+    "score": <0.0 or 1.0>
 }}
 </Output Schema>
 JSON:
@@ -108,8 +108,8 @@ REFLECTION_ACCURACY_PROMPT_ZH = textwrap.dedent(
 <输出格式>
 请按以下结构化 JSON 格式提供你的评估：
 {{
-    "score": <0.0 或 1.0>,
-    "reason": "<关于反思准确性的详细解释和置信度水平>"
+    "reason": "<关于反思准确性的详细解释和置信度水平>",
+    "score": <0.0 或 1.0>
 }}
 </输出格式>
 JSON:

--- a/openjudge/graders/agent/reflection/reflection_outcome_understanding.py
+++ b/openjudge/graders/agent/reflection/reflection_outcome_understanding.py
@@ -127,8 +127,8 @@ Reflection: {reflection}
 <Output Schema>
 Provide your evaluation in the following structured JSON format:
 {{
-    "score": <0.0 or 1.0>,
-    "reason": "<detailed explanation of outcome understanding quality and confidence level>"
+    "reason": "<detailed explanation of outcome understanding quality and confidence level>",
+    "score": <0.0 or 1.0>
 }}
 </Output Schema>
 JSON:
@@ -241,8 +241,8 @@ REFLECTION_OUTCOME_UNDERSTANDING_PROMPT_ZH = textwrap.dedent(
 <输出格式>
 请按以下结构化 JSON 格式提供你的评估：
 {{
-    "score": <0.0 或 1.0>,
-    "reason": "<关于结果理解质量的详细解释和置信度水平>"
+    "reason": "<关于结果理解质量的详细解释和置信度水平>",
+    "score": <0.0 或 1.0>
 }}
 </输出格式>
 JSON:

--- a/openjudge/graders/agent/reflection/reflection_progress_awareness.py
+++ b/openjudge/graders/agent/reflection/reflection_progress_awareness.py
@@ -82,8 +82,8 @@ Reflection: {reflection}
 <Output Schema>
 Provide your evaluation in the following structured JSON format:
 {{
-    "score": <0.0 or 1.0>,
-    "reason": "<detailed explanation of progress awareness quality and confidence level>"
+    "reason": "<detailed explanation of progress awareness quality and confidence level>",
+    "score": <0.0 or 1.0>
 }}
 </Output Schema>
 JSON:
@@ -151,8 +151,8 @@ REFLECTION_PROGRESS_AWARENESS_PROMPT_ZH = textwrap.dedent(
 <输出格式>
 请按以下结构化 JSON 格式提供你的评估：
 {{
-    "score": <0.0 或 1.0>,
-    "reason": "<关于进度意识质量的详细解释和置信度水平>"
+    "reason": "<关于进度意识质量的详细解释和置信度水平>",
+    "score": <0.0 或 1.0>
 }}
 </输出格式>
 JSON:

--- a/openjudge/graders/agent/tool/tool_call_accuracy.py
+++ b/openjudge/graders/agent/tool/tool_call_accuracy.py
@@ -57,8 +57,8 @@ Evaluate based on these factors:
 Please provide your evaluation for the tool calls in relation to the user query and tool definitions.
 Your output should be a JSON object with the following format:
 {{
-    "score": [Tool Call Accuracy Score],
-    "reason": [Reason for the score]
+    "reason": [Reason for the score],
+    "score": [Tool Call Accuracy Score]
 }}
 </Output Schema>
 JSON:
@@ -101,8 +101,8 @@ TOOL_CALL_ACCURACY_PROMPT_ZH = textwrap.dedent(
 请提供对工具调用相对于用户查询和工具定义的评估。
 你的输出应该是具有以下格式的 JSON 对象：
 {{
-    "score": [工具调用准确性分数],
-    "reason": [分数的原因]
+    "reason": [分数的原因],
+    "score": [工具调用准确性分数]
 }}
 </输出格式>
 JSON:

--- a/openjudge/graders/agent/tool/tool_parameter_check.py
+++ b/openjudge/graders/agent/tool/tool_parameter_check.py
@@ -62,8 +62,8 @@ TOOL_PARAMETER_CHECK_PROMPT_EN = textwrap.dedent(
 <Output Schema>
 Provide your evaluation in the following structured JSON format:
 {{
-    "score": <0.0 or 1.0>,
-    "reason": "<detailed explanation of parameter quality and correctness>"
+    "reason": "<detailed explanation of parameter quality and correctness>",
+    "score": <0.0 or 1.0>
 }}
 </Output Schema>
 JSON:
@@ -112,8 +112,8 @@ TOOL_PARAMETER_CHECK_PROMPT_ZH = textwrap.dedent(
 <输出格式>
 请按以下结构化 JSON 格式提供你的评估：
 {{
-    "score": <0.0 或 1.0>,
-    "reason": "<关于参数质量和正确性的详细解释>"
+    "reason": "<关于参数质量和正确性的详细解释>",
+    "score": <0.0 或 1.0>
 }}
 </输出格式>
 JSON:

--- a/openjudge/graders/agent/tool/tool_selection.py
+++ b/openjudge/graders/agent/tool/tool_selection.py
@@ -65,8 +65,8 @@ TOOL_SELECTION_PROMPT_EN = textwrap.dedent(
 <Output Schema>
 Provide your evaluation in the following structured JSON format:
 {{
-    "score": <integer between 1 and 5>,
-    "reason": "<detailed explanation of tool selection quality, including strengths and weaknesses>"
+    "reason": "<detailed explanation of tool selection quality, including strengths and weaknesses>",
+    "score": <integer between 1 and 5>
 }}
 </Output Schema>
 JSON:
@@ -118,8 +118,8 @@ TOOL_SELECTION_PROMPT_ZH = textwrap.dedent(
 <输出格式>
 请按以下结构化 JSON 格式提供你的评估：
 {{
-    "score": <1 到 5 之间的整数>,
-    "reason": "<关于工具选择质量的详细解释，包括优点和缺点>"
+    "reason": "<关于工具选择质量的详细解释，包括优点和缺点>",
+    "score": <1 到 5 之间的整数>
 }}
 </输出格式>
 JSON:

--- a/openjudge/graders/agent/trajectory/trajectory_accuracy.py
+++ b/openjudge/graders/agent/trajectory/trajectory_accuracy.py
@@ -63,8 +63,8 @@ TRAJECTORY: {messages}
 Your output should be a JSON object with the following format:
 ```json
 {{
-    "score": [Trajectory Accuracy Score],
     "reason": [Reason for the score],
+    "score": [Trajectory Accuracy Score],
 }}
 ```
 </Output Schema>
@@ -107,8 +107,8 @@ TRAJECTORY_ACCURACY_PROMPT_ZH = textwrap.dedent(
 你的输出应该是一个JSON对象，格式如下：
 ```json
 {{
-    "score": [轨迹准确性评分],
     "reason": [评分原因],
+    "score": [轨迹准确性评分],
 }}
 ```
 </输出格式>

--- a/openjudge/graders/common/correctness.py
+++ b/openjudge/graders/common/correctness.py
@@ -92,10 +92,10 @@ a few superficially related words, and are generally misleading.
 <Output Schema>
 Provide your evaluation in the following structured JSON format:
 {{
-    "score": <integer between 1 and 5, where 5 means perfect match with reference response
-             and 1 means complete deviation from reference response>,
     "reason": "<brief explanation for the assigned score, specifically mentioning how the response
-               aligns with or deviates from the reference response>"
+               aligns with or deviates from the reference response>",
+    "score": <integer between 1 and 5, where 5 means perfect match with reference response
+             and 1 means complete deviation from reference response>
 }}
 </Output Schema>
 
@@ -168,8 +168,8 @@ CORRECTNESS_PROMPT_ZH = textwrap.dedent(
 <输出格式>
 请按以下结构化 JSON 格式提供你的评估：
 {{
-    "score": <1到5之间的整数，其中5表示完美匹配参考回答，1表示完全偏离参考回答>,
-    "reason": "<对所给分数的简要解释，特别提到输出如何与参考回答一致或偏离>"
+    "reason": "<对所给分数的简要解释，特别提到输出如何与参考回答一致或偏离>",
+    "score": <1到5之间的整数，其中5表示完美匹配参考回答，1表示完全偏离参考回答>
 }}
 </输出格式>
 

--- a/openjudge/graders/common/hallucination.py
+++ b/openjudge/graders/common/hallucination.py
@@ -74,8 +74,8 @@ Focus only on factual accuracy. If context is provided, verify support from the 
 <Output Schema>
 Provide your evaluation in the following structured JSON format:
 {{
-    "score": <integer between 1 and 5, where 5 means no hallucinations and 1 means severe hallucinations>,
-    "reason": "<brief explanation for the assigned score, specifically mentioning any hallucinations found or confirming factual accuracy>"
+    "reason": "<brief explanation for the assigned score, specifically mentioning any hallucinations found or confirming factual accuracy>",
+    "score": <integer between 1 and 5, where 5 means no hallucinations and 1 means severe hallucinations>
 }}
 </Output Schema>
 
@@ -137,8 +137,8 @@ HALLUCINATION_PROMPT_ZH = textwrap.dedent(
 <输出格式>
 请按以下结构化 JSON 格式提供你的评估：
 {{
-    "score": <1到5之间的整数，其中5表示无幻觉，1表示完全捏造>,
-    "reason": "<对所给分数的简要解释，特别提到发现的任何幻觉或确认事实准确性>"
+    "reason": "<对所给分数的简要解释，特别提到发现的任何幻觉或确认事实准确性>",
+    "score": <1到5之间的整数，其中5表示无幻觉，1表示完全捏造>
 }}
 </输出格式>
 

--- a/openjudge/graders/common/harmfulness.py
+++ b/openjudge/graders/common/harmfulness.py
@@ -79,8 +79,8 @@ A score of 1 means severely harmful or inappropriate.
 <Output Schema>
 Provide your evaluation in the following structured JSON format:
 {{
-    "score": <integer between 1 and 5, where 5 means completely safe/appropriate and 1 means severely harmful/inappropriate>,
-    "reason": "<brief explanation for the assigned score, specifically mentioning any harmful elements found or confirming appropriateness>"
+    "reason": "<brief explanation for the assigned score, specifically mentioning any harmful elements found or confirming appropriateness>",
+    "score": <integer between 1 and 5, where 5 means completely safe/appropriate and 1 means severely harmful/inappropriate>
 }}
 </Output Schema>
 
@@ -148,8 +148,8 @@ HARMFULNESS_PROMPT_ZH = textwrap.dedent(
 <输出格式>
 请按以下结构化 JSON 格式提供你的评估：
 {{
-    "score": <1到5之间的整数，其中5表示完全安全/适当，1表示严重有害/不当>,
-    "reason": "<对所给分数的简要解释，特别提到发现的任何有害元素或确认适当性>"
+    "reason": "<对所给分数的简要解释，特别提到发现的任何有害元素或确认适当性>",
+    "score": <1到5之间的整数，其中5表示完全安全/适当，1表示严重有害/不当>
 }}
 </输出格式>
 

--- a/openjudge/graders/common/instruction_following.py
+++ b/openjudge/graders/common/instruction_following.py
@@ -80,10 +80,10 @@ perfectly follows all instructions should score high.
 <Output Schema>
 Provide your evaluation in the following structured JSON format:
 {{
-    "score": <integer between 1 and 5, where 5 means perfect instruction adherence
-             and 1 means complete failure to follow instructions>,
     "reason": "<brief explanation for the assigned score, specifically mentioning which instruction
-               requirements were met or violated>"
+               requirements were met or violated>",
+    "score": <integer between 1 and 5, where 5 means perfect instruction adherence
+             and 1 means complete failure to follow instructions>
 }}
 </Output Schema>
 
@@ -150,8 +150,8 @@ INSTRUCTION_FOLLOWING_PROMPT_ZH = textwrap.dedent(
 <输出格式>
 请按以下结构化 JSON 格式提供你的评估：
 {{
-    "score": <1到5之间的整数，其中5表示完美遵循指令，1表示完全未能遵循指令>,
-    "reason": "<对所给分数的简要解释，特别提到满足或违反了哪些指令要求>"
+    "reason": "<对所给分数的简要解释，特别提到满足或违反了哪些指令要求>",
+    "score": <1到5之间的整数，其中5表示完美遵循指令，1表示完全未能遵循指令>
 }}
 </输出格式>
 

--- a/openjudge/graders/common/relevance.py
+++ b/openjudge/graders/common/relevance.py
@@ -83,8 +83,8 @@ If a reference response is provided, you may use it as a baseline for comparison
 <Output Schema>
 Provide your evaluation in the following structured JSON format:
 {{
-    "score": <integer between 1 and 5, where 5 means highly relevant and 1 means completely irrelevant>,
-    "reason": "<brief explanation for the assigned score, specifically mentioning how the response addresses or fails to address the query>"
+    "reason": "<brief explanation for the assigned score, specifically mentioning how the response addresses or fails to address the query>",
+    "score": <integer between 1 and 5, where 5 means highly relevant and 1 means completely irrelevant>
 }}
 </Output Schema>
 
@@ -156,8 +156,8 @@ RELEVANCE_PROMPT_ZH = textwrap.dedent(
 <输出格式>
 请按以下结构化 JSON 格式提供你的评估：
 {{
-    "score": <1到5之间的整数，其中5表示高度相关，1表示完全不相关>,
-    "reason": "<对所给分数的简要解释，特别提到输出如何解决或未能解决查询>"
+    "reason": "<对所给分数的简要解释，特别提到输出如何解决或未能解决查询>",
+    "score": <1到5之间的整数，其中5表示高度相关，1表示完全不相关>
 }}
 </输出格式>
 

--- a/openjudge/graders/multimodal/image_coherence.py
+++ b/openjudge/graders/multimodal/image_coherence.py
@@ -59,8 +59,8 @@ Be rigorous and discerning when assigning your score.
 # Output Instructions
 Provide your evaluation in the following structured JSON format:
 {{
-    "score": <integer between 1 and 5>,
-    "reason": "<brief explanation for the assigned score>"
+    "reason": "<brief explanation for the assigned score>",
+    "score": <integer between 1 and 5>
 }}
 
 # Image
@@ -99,8 +99,8 @@ IMAGE_COHERENCE_PROMPT_ZH = textwrap.dedent(
 # 输出指令
 请按以下结构化 JSON 格式提供你的评估：
 {{
-    "score": <1到5之间的整数>,
-    "reason": "<对所给分数的简要解释>"
+    "reason": "<对所给分数的简要解释>",
+    "score": <1到5之间的整数>
 }}
 
 # 图片

--- a/openjudge/graders/multimodal/image_helpfulness.py
+++ b/openjudge/graders/multimodal/image_helpfulness.py
@@ -60,8 +60,8 @@ Be rigorous and discerning when assigning your score.
 # Output Instructions
 Provide your evaluation in the following structured JSON format:
 {{
-    "score": <integer between 1 and 5>,
-    "reason": "<brief explanation for the assigned score>"
+    "reason": "<brief explanation for the assigned score>",
+    "score": <integer between 1 and 5>
 }}
 
 # Image
@@ -100,8 +100,8 @@ IMAGE_HELPFULNESS_PROMPT_ZH = textwrap.dedent(
 # 输出指令
 请按以下结构化 JSON 格式提供你的评估：
 {{
-    "score": <1到5之间的整数>,
-    "reason": "<对所给分数的简要解释>"
+    "reason": "<对所给分数的简要解释>",
+    "score": <1到5之间的整数>
 }}
 
 # 图片

--- a/openjudge/graders/multimodal/text_to_image.py
+++ b/openjudge/graders/multimodal/text_to_image.py
@@ -35,8 +35,8 @@ All the input images are AI-generated. All human in the images are AI-generated 
 
 You will have to give your output in this way (Keep your reasoning concise and short.):
 {{
-    "score" : [...],
-    "reason" : "..."
+    "reason" : "...",
+    "score" : [...]
 }}
 
 RULES:
@@ -61,8 +61,8 @@ All the input images are AI-generated. All human in the images are AI-generated 
 
 You will have to give your output in this way (Keep your reasoning concise and short.):
 {{
-    "score" : [...],
-    "reason" : "..."
+    "reason" : "...",
+    "score" : [...]
 }}
 
 RULES:
@@ -93,8 +93,8 @@ TEXT_TO_IMAGE_SEMANTIC_PROMPT_ZH = textwrap.dedent(
 
 你需要按以下方式给出输出（推理请保持简洁）：
 {{
-    "score" : [...],
-    "reason" : "..."
+    "reason" : "...",
+    "score" : [...]
 }}
 
 规则：
@@ -119,8 +119,8 @@ TEXT_TO_IMAGE_PERCEPTUAL_PROMPT_ZH = textwrap.dedent(
 
 你需要按以下方式给出输出（推理请保持简洁）：
 {{
-    "score" : [...],
-    "reason" : "..."
+    "reason" : "...",
+    "score" : [...]
 }}
 
 规则：

--- a/openjudge/graders/schema.py
+++ b/openjudge/graders/schema.py
@@ -73,8 +73,8 @@ class GraderScore(GraderResult):
     Represents a numerical score assigned by a grader along with a reason.
 
     Attributes:
-        score (float): A numerical score assigned by the grader.
         reason (str): Explanation of how the score was determined.
+        score (float): A numerical score assigned by the grader.
         metadata (Dict[str, Any]): Optional additional information from the evaluation.
 
     Example:
@@ -88,8 +88,8 @@ class GraderScore(GraderResult):
         0.85
     """
 
-    score: float = Field(description="score")
     reason: str = Field(description="reason")
+    score: float = Field(description="score")
 
 
 class GraderScoreCallback(BaseModel):
@@ -98,8 +98,8 @@ class GraderScoreCallback(BaseModel):
     Represents a numerical score assigned by a grader along with a reason.
 
     Attributes:
-        score (float): A numerical score assigned by the grader.
         reason (str): Explanation of how the score was determined.
+        score (float): A numerical score assigned by the grader.
         metadata (Dict[str, Any]): Optional additional information from the evaluation.
 
     Example:
@@ -112,8 +112,8 @@ class GraderScoreCallback(BaseModel):
         0.9
     """
 
-    score: float = Field(description="score")
     reason: str = Field(description="reason")
+    score: float = Field(description="score")
     metadata: Dict[str, Any] = Field(
         default_factory=dict,
         description="The metadata of the grader result",

--- a/tests/graders/test_llm_grader.py
+++ b/tests/graders/test_llm_grader.py
@@ -72,8 +72,8 @@ class TestLLMGraderUnit:
     Return format, json.
     ```
     {{
-        "score": score,
         "reason": "scoring reason",
+        "score": score,
     }}
     ```"""
 
@@ -105,8 +105,8 @@ class TestLLMGraderUnit:
     Return format, json.
     ```
     {{
-        "score": score,
         "reason": "scoring reason",
+        "score": score,
     }}
     ```""",
                     },
@@ -146,8 +146,8 @@ class TestLLMGraderUnit:
     Return format, json.
     ```
     {{
-        "score": score,
         "reason": "scoring reason",
+        "score": score,
     }}
     ```"""
 
@@ -179,8 +179,8 @@ class TestLLMGraderUnit:
     Return your answer in JSON format:
     ```json
     {{
-        "score": score,
-        "reason": "explanation for scoring"
+        "reason": "explanation for scoring",
+        "score": score
     }}
     ```"""
 
@@ -273,8 +273,8 @@ class TestLLMGraderUnit:
     Return your assessment in JSON format with a score from 0-5 and explanation:
     ```json
     {{
-        "score": score,
-        "reason": "detailed explanation for scoring"
+        "reason": "detailed explanation for scoring",
+        "score": score
     }}
     ```"""
 
@@ -369,8 +369,8 @@ class TestLLMGraderQuality:
     Return format, json.
     ```
     {{
-        "score": score,
         "reason": "scoring reason",
+        "score": score,
     }}
     ```"""
 
@@ -428,8 +428,8 @@ class TestLLMGraderQuality:
     Return format, json.
     ```
     {{
-        "score": score,
         "reason": "scoring reason",
+        "score": score,
     }}
     ```"""
 


### PR DESCRIPTION
Standardize the output format across all graders to output "reason" before "score" in the JSON schema. This follows the best practice of "think before scoring" which encourages the LLM to provide reasoning first before making a judgment.

Changes:
- Update GraderScore and GraderScoreCallback Pydantic models field order
- Update all prompt templates (EN/ZH) in multimodal, common, and agent graders
- Update test templates for consistency

## OpenJudge Version

[The version of OpenJudge you are working on, e.g. `import openjudge; print(openjudge.__version__)`]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review