### PR TITLE
feat: add finance graders for stock/event/industry/macro analysis

### DIFF
--- a/cookbooks/finance_grader/industry_research/characteristics_analysis.py
+++ b/cookbooks/finance_grader/industry_research/characteristics_analysis.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 from loguru import logger
 
+from openjudge.evaluation_strategy import BaseEvaluationStrategy
 from openjudge.graders.base_grader import GraderError, GraderMode, GraderRank
 from openjudge.graders.llm_grader import LLMGrader
 from openjudge.models.base_chat_model import BaseChatModel
@@ -73,8 +74,8 @@ c. Each sub-argument should have a logical relationship with the conclusion, not
 <Output Schema>
 Please output your assessment in the following JSON format strictly:
 {{
-    "rank": <[1, 2] or [2, 1]>,
-    "reason": "<detailed explanation of your evaluation reasoning, including performance comparison under each evaluation criterion>"
+    "reason": "<detailed explanation of your evaluation reasoning, including performance comparison under each evaluation criterion>",
+    "rank": <[1, 2] or [2, 1]>
 }}
 </Output Schema>
 
@@ -138,8 +139,8 @@ c. 各子论点应和结论有逻辑关系，非孤立罗列，确保逻辑自�
 <输出格式>
 请按以下结构化 JSON 格式严格输出你的评估：
 {{
-    "rank": <[1, 2] 或 [2, 1]>,
-    "reason": "<详细解释你的评估理由，包括在各个评估标准下的表现对比>"
+    "reason": "<详细解释你的评估理由，包括在各个评估标准下的表现对比>",
+    "rank": <[1, 2] 或 [2, 1]>
 }}
 </输出格式>
 
@@ -220,6 +221,7 @@ class CharacteristicsAnalysisGrader(LLMGrader):
         model: BaseChatModel | dict,
         template: Optional[PromptTemplate] = None,
         language: LanguageEnum = LanguageEnum.ZH,
+        strategy: BaseEvaluationStrategy | None = None,
     ):
         """
         Initialize CharacteristicsAnalysisGrader.
@@ -236,6 +238,7 @@ class CharacteristicsAnalysisGrader(LLMGrader):
             model=model,
             template=template or DEFAULT_CHARACTERISTICS_ANALYSIS_TEMPLATE,
             language=language,
+            strategy=strategy,
         )
 
     async def _aevaluate(
@@ -256,6 +259,13 @@ class CharacteristicsAnalysisGrader(LLMGrader):
 
         Returns:
             GraderRank: Rank result with [1, 2] if answer_1 is better, [2, 1] if answer_2 is better
+
+        Example:
+            >>> result = await grader.aevaluate(
+            ...     query="分析新能源汽车行业的特性",
+            ...     answer_1="新能源汽车行业发展迅速。",
+            ...     answer_2="新能源汽车行业产业链完整，上游包括锂矿、电池材料..."
+            ... )
         """
         try:
             result = await super()._aevaluate(

--- a/cookbooks/finance_grader/industry_research/underlying_comparison.py
+++ b/cookbooks/finance_grader/industry_research/underlying_comparison.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 from loguru import logger
 
+from openjudge.evaluation_strategy import BaseEvaluationStrategy
 from openjudge.graders.base_grader import GraderError, GraderMode, GraderRank
 from openjudge.graders.llm_grader import LLMGrader
 from openjudge.models.base_chat_model import BaseChatModel
@@ -71,8 +72,8 @@ c. Each sub-argument should have a logical relationship with the conclusion, not
 <Output Schema>
 Please output your assessment in the following JSON format strictly:
 {{
-    "rank": <[1, 2] or [2, 1]>,
-    "reason": "<detailed explanation of your evaluation reasoning, including performance comparison under each evaluation criterion>"
+    "reason": "<detailed explanation of your evaluation reasoning, including performance comparison under each evaluation criterion>",
+    "rank": <[1, 2] or [2, 1]>
 }}
 </Output Schema>
 
@@ -134,8 +135,8 @@ c. 各子论点应和结论有逻辑关系，非孤立罗列，确保逻辑自�
 <输出格式>
 请按以下结构化 JSON 格式严格输出你的评估：
 {{
-    "rank": <[1, 2] 或 [2, 1]>,
-    "reason": "<详细解释你的评估理由，包括在各个评估标准下的表现对比>"
+    "reason": "<详细解释你的评估理由，包括在各个评估标准下的表现对比>",
+    "rank": <[1, 2] 或 [2, 1]>
 }}
 </输出格式>
 
@@ -216,6 +217,7 @@ class UnderlyingComparisonGrader(LLMGrader):
         model: BaseChatModel | dict,
         template: Optional[PromptTemplate] = None,
         language: LanguageEnum = LanguageEnum.ZH,
+        strategy: BaseEvaluationStrategy | None = None,
     ):
         """
         Initialize UnderlyingComparisonGrader.
@@ -232,6 +234,7 @@ class UnderlyingComparisonGrader(LLMGrader):
             model=model,
             template=template or DEFAULT_UNDERLYING_COMPARISON_TEMPLATE,
             language=language,
+            strategy=strategy,
         )
 
     async def _aevaluate(
@@ -252,6 +255,13 @@ class UnderlyingComparisonGrader(LLMGrader):
 
         Returns:
             GraderRank: Rank result with [1, 2] if answer_1 is better, [2, 1] if answer_2 is better
+
+        Example:
+            >>> result = await grader.aevaluate(
+            ...     query="对比分析宁德时代和比亚迪",
+            ...     answer_1="两家都是动力电池龙头企业。",
+            ...     answer_2="宁德时代ROE 25%，专注电池；比亚迪ROE 18%，垂直整合..."
+            ... )
         """
         try:
             result = await super()._aevaluate(

--- a/cookbooks/finance_grader/macro_analysis/concept_explanation.py
+++ b/cookbooks/finance_grader/macro_analysis/concept_explanation.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 from loguru import logger
 
+from openjudge.evaluation_strategy import BaseEvaluationStrategy
 from openjudge.graders.base_grader import GraderError, GraderMode, GraderRank
 from openjudge.graders.llm_grader import LLMGrader
 from openjudge.models.base_chat_model import BaseChatModel
@@ -59,8 +60,8 @@ Criterion 2. Background and Historical Comparison: When explaining, appropriatel
 <Output Schema>
 Please output your assessment in the following JSON format strictly:
 {{
-    "rank": <[1, 2] or [2, 1]>,
-    "reason": "<detailed explanation of your evaluation reasoning, including performance comparison under each evaluation criterion>"
+    "reason": "<detailed explanation of your evaluation reasoning, including performance comparison under each evaluation criterion>",
+    "rank": <[1, 2] or [2, 1]>
 }}
 </Output Schema>
 
@@ -110,8 +111,8 @@ CONCEPT_EXPLANATION_PROMPT_ZH = textwrap.dedent(
 <输出格式>
 请按以下结构化 JSON 格式严格输出你的评估：
 {{
-    "rank": <[1, 2] 或 [2, 1]>,
-    "reason": "<详细解释你的评估理由，包括在各个评估标准下的表现对比>"
+    "reason": "<详细解释你的评估理由，包括在各个评估标准下的表现对比>",
+    "rank": <[1, 2] 或 [2, 1]>
 }}
 </输出格式>
 
@@ -191,6 +192,7 @@ class ConceptExplanationGrader(LLMGrader):
         model: BaseChatModel | dict,
         template: Optional[PromptTemplate] = None,
         language: LanguageEnum = LanguageEnum.ZH,
+        strategy: BaseEvaluationStrategy | None = None,
     ):
         """
         Initialize ConceptExplanationGrader.
@@ -207,6 +209,7 @@ class ConceptExplanationGrader(LLMGrader):
             model=model,
             template=template or DEFAULT_CONCEPT_EXPLANATION_TEMPLATE,
             language=language,
+            strategy=strategy,
         )
 
     async def _aevaluate(
@@ -227,6 +230,13 @@ class ConceptExplanationGrader(LLMGrader):
 
         Returns:
             GraderRank: Rank result with [1, 2] if answer_1 is better, [2, 1] if answer_2 is better
+
+        Example:
+            >>> result = await grader.aevaluate(
+            ...     query="什么是量化宽松政策？",
+            ...     answer_1="量化宽松是一种货币政策。",
+            ...     answer_2="量化宽松(QE)是央行通过购买国债等资产向市场注入流动性..."
+            ... )
         """
         try:
             result = await super()._aevaluate(

--- a/cookbooks/finance_grader/macro_analysis/macro_analysis.py
+++ b/cookbooks/finance_grader/macro_analysis/macro_analysis.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 from loguru import logger
 
+from openjudge.evaluation_strategy import BaseEvaluationStrategy
 from openjudge.graders.base_grader import GraderError, GraderMode, GraderRank
 from openjudge.graders.llm_grader import LLMGrader
 from openjudge.models.base_chat_model import BaseChatModel
@@ -72,8 +73,8 @@ c. Each sub-argument should have a logical relationship with the conclusion, not
 <Output Schema>
 Please output your assessment in the following JSON format strictly:
 {{
-    "rank": <[1, 2] or [2, 1]>,
-    "reason": "<detailed explanation of your evaluation reasoning, including performance comparison under each evaluation criterion>"
+    "reason": "<detailed explanation of your evaluation reasoning, including performance comparison under each evaluation criterion>",
+    "rank": <[1, 2] or [2, 1]>
 }}
 </Output Schema>
 
@@ -136,8 +137,8 @@ c. 各子论点应和结论有逻辑关系，非孤立罗列，确保逻辑自�
 <输出格式>
 请按以下结构化 JSON 格式严格输出你的评估：
 {{
-    "rank": <[1, 2] 或 [2, 1]>,
-    "reason": "<详细解释你的评估理由，包括在各个评估标准下的表现对比>"
+    "reason": "<详细解释你的评估理由，包括在各个评估标准下的表现对比>",
+    "rank": <[1, 2] 或 [2, 1]>
 }}
 </输出格式>
 
@@ -218,6 +219,7 @@ class MacroAnalysisGrader(LLMGrader):
         model: BaseChatModel | dict,
         template: Optional[PromptTemplate] = None,
         language: LanguageEnum = LanguageEnum.ZH,
+        strategy: BaseEvaluationStrategy | None = None,
     ):
         """
         Initialize MacroAnalysisGrader.
@@ -234,6 +236,7 @@ class MacroAnalysisGrader(LLMGrader):
             model=model,
             template=template or DEFAULT_MACRO_ANALYSIS_TEMPLATE,
             language=language,
+            strategy=strategy,
         )
 
     async def _aevaluate(
@@ -254,6 +257,13 @@ class MacroAnalysisGrader(LLMGrader):
 
         Returns:
             GraderRank: Rank result with [1, 2] if answer_1 is better, [2, 1] if answer_2 is better
+
+        Example:
+            >>> result = await grader.aevaluate(
+            ...     query="分析当前中国宏观经济形势",
+            ...     answer_1="经济形势总体稳定。",
+            ...     answer_2="当前中国经济呈现稳中向好态势：GDP增速5.2%，CPI温和..."
+            ... )
         """
         try:
             result = await super()._aevaluate(

--- a/cookbooks/finance_grader/stock_analysis/fundamental_analysis.py
+++ b/cookbooks/finance_grader/stock_analysis/fundamental_analysis.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 from loguru import logger
 
+from openjudge.evaluation_strategy import BaseEvaluationStrategy
 from openjudge.graders.base_grader import GraderError, GraderMode, GraderRank
 from openjudge.graders.llm_grader import LLMGrader
 from openjudge.models.base_chat_model import BaseChatModel
@@ -71,8 +72,8 @@ c. Each sub-argument should have a logical relationship with the conclusion, not
 <Output Schema>
 Please output your assessment in the following JSON format strictly:
 {{
-    "rank": <[1, 2] or [2, 1]>,
-    "reason": "<detailed explanation of your evaluation reasoning, including performance comparison under each evaluation criterion>"
+    "reason": "<detailed explanation of your evaluation reasoning, including performance comparison under each evaluation criterion>",
+    "rank": <[1, 2] or [2, 1]>
 }}
 </Output Schema>
 
@@ -134,8 +135,8 @@ c. 各子论点应和结论有逻辑关系，非孤立罗列，确保逻辑自�
 <输出格式>
 请按以下结构化 JSON 格式严格输出你的评估：
 {{
-    "rank": <[1, 2] 或 [2, 1]>,
-    "reason": "<详细解释你的评估理由，包括在各个评估标准下的表现对比>"
+    "reason": "<详细解释你的评估理由，包括在各个评估标准下的表现对比>",
+    "rank": <[1, 2] 或 [2, 1]>
 }}
 </输出格式>
 
@@ -216,6 +217,7 @@ class FundamentalAnalysisGrader(LLMGrader):
         model: BaseChatModel | dict,
         template: Optional[PromptTemplate] = None,
         language: LanguageEnum = LanguageEnum.ZH,
+        strategy: BaseEvaluationStrategy | None = None,
     ):
         """
         Initialize FundamentalAnalysisGrader.
@@ -232,6 +234,7 @@ class FundamentalAnalysisGrader(LLMGrader):
             model=model,
             template=template or DEFAULT_FUNDAMENTAL_ANALYSIS_TEMPLATE,
             language=language,
+            strategy=strategy,
         )
 
     async def _aevaluate(
@@ -252,6 +255,13 @@ class FundamentalAnalysisGrader(LLMGrader):
 
         Returns:
             GraderRank: Rank result with [1, 2] if answer_1 is better, [2, 1] if answer_2 is better
+
+        Example:
+            >>> result = await grader.aevaluate(
+            ...     query="分析贵州茅台的基本面",
+            ...     answer_1="茅台是白酒龙头企业。",
+            ...     answer_2="茅台基本面优秀：毛利率91%，ROE 30%，现金流充沛..."
+            ... )
         """
         try:
             result = await super()._aevaluate(

--- a/cookbooks/finance_grader/stock_analysis/overall_logic.py
+++ b/cookbooks/finance_grader/stock_analysis/overall_logic.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 from loguru import logger
 
+from openjudge.evaluation_strategy import BaseEvaluationStrategy
 from openjudge.graders.base_grader import GraderError, GraderMode, GraderRank
 from openjudge.graders.llm_grader import LLMGrader
 from openjudge.models.base_chat_model import BaseChatModel
@@ -67,8 +68,8 @@ c. Sub-arguments have no contradictions or conflicts in content
 <Output Schema>
 Please output your assessment in the following JSON format strictly:
 {{
-    "rank": <[1, 2] or [2, 1]>,
-    "reason": "<detailed explanation of your evaluation reasoning, including performance comparison under each evaluation criterion>"
+    "reason": "<detailed explanation of your evaluation reasoning, including performance comparison under each evaluation criterion>",
+    "rank": <[1, 2] or [2, 1]>
 }}
 </Output Schema>
 
@@ -126,8 +127,8 @@ c. 各子论点内容没有矛盾或者冲突
 <输出格式>
 请按以下结构化 JSON 格式严格输出你的评估：
 {{
-    "rank": <[1, 2] 或 [2, 1]>,
-    "reason": "<详细解释你的评估理由，包括在各个评估标准下的表现对比>"
+    "reason": "<详细解释你的评估理由，包括在各个评估标准下的表现对比>",
+    "rank": <[1, 2] 或 [2, 1]>
 }}
 </输出格式>
 
@@ -208,6 +209,7 @@ class OverallLogicGrader(LLMGrader):
         model: BaseChatModel | dict,
         template: Optional[PromptTemplate] = None,
         language: LanguageEnum = LanguageEnum.ZH,
+        strategy: BaseEvaluationStrategy | None = None,
     ):
         """
         Initialize OverallLogicGrader.
@@ -224,6 +226,7 @@ class OverallLogicGrader(LLMGrader):
             model=model,
             template=template or DEFAULT_OVERALL_LOGIC_TEMPLATE,
             language=language,
+            strategy=strategy,
         )
 
     async def _aevaluate(
@@ -244,6 +247,13 @@ class OverallLogicGrader(LLMGrader):
 
         Returns:
             GraderRank: Rank result with [1, 2] if answer_1 is better, [2, 1] if answer_2 is better
+
+        Example:
+            >>> result = await grader.aevaluate(
+            ...     query="分析宁德时代的投资逻辑",
+            ...     answer_1="新能源行业前景好。",
+            ...     answer_2="投资逻辑：1)行业空间：全球电动车渗透率仅15%..."
+            ... )
         """
         try:
             result = await super()._aevaluate(

--- a/cookbooks/finance_grader/stock_analysis/stock_risk_analysis.py
+++ b/cookbooks/finance_grader/stock_analysis/stock_risk_analysis.py
@@ -12,6 +12,7 @@ from typing import Optional
 
 from loguru import logger
 
+from openjudge.evaluation_strategy import BaseEvaluationStrategy
 from openjudge.graders.base_grader import GraderError, GraderMode, GraderRank
 from openjudge.graders.llm_grader import LLMGrader
 from openjudge.models.base_chat_model import BaseChatModel
@@ -71,8 +72,8 @@ Criterion 3. Logical Rigor of Risk Analysis: Assess whether the risk analysis ha
 <Output Schema>
 Please output your assessment in the following JSON format strictly:
 {{
-    "rank": <[1, 2] or [2, 1]>,
-    "reason": "<detailed explanation of your evaluation reasoning, including performance comparison under each evaluation criterion>"
+    "reason": "<detailed explanation of your evaluation reasoning, including performance comparison under each evaluation criterion>",
+    "rank": <[1, 2] or [2, 1]>
 }}
 </Output Schema>
 
@@ -133,8 +134,8 @@ c. 公司或者所在行业特有的风险(如 "矿产公司可能有安全事�
 <输出格式>
 请按以下结构化 JSON 格式严格输出你的评估：
 {{
-    "rank": <[1, 2] 或 [2, 1]>,
-    "reason": "<详细解释你的评估理由，包括在各个评估标准下的表现对比>"
+    "reason": "<详细解释你的评估理由，包括在各个评估标准下的表现对比>",
+    "rank": <[1, 2] 或 [2, 1]>
 }}
 </输出格式>
 
@@ -215,6 +216,7 @@ class StockRiskAnalysisGrader(LLMGrader):
         model: BaseChatModel | dict,
         template: Optional[PromptTemplate] = None,
         language: LanguageEnum = LanguageEnum.ZH,
+        strategy: BaseEvaluationStrategy | None = None,
     ):
         """
         Initialize StockRiskAnalysisGrader.
@@ -231,6 +233,7 @@ class StockRiskAnalysisGrader(LLMGrader):
             model=model,
             template=template or DEFAULT_STOCK_RISK_ANALYSIS_TEMPLATE,
             language=language,
+            strategy=strategy,
         )
 
     async def _aevaluate(
@@ -251,6 +254,13 @@ class StockRiskAnalysisGrader(LLMGrader):
 
         Returns:
             GraderRank: Rank result with [1, 2] if answer_1 is better, [2, 1] if answer_2 is better
+
+        Example:
+            >>> result = await grader.aevaluate(
+            ...     query="分析比亚迪股票的风险",
+            ...     answer_1="存在市场竞争风险。",
+            ...     answer_2="主要风险：1)补贴退坡风险 2)原材料价格波动 3)技术迭代..."
+            ... )
         """
         try:
             result = await super()._aevaluate(

--- a/cookbooks/finance_grader/stock_search/search_integrity.py
+++ b/cookbooks/finance_grader/stock_search/search_integrity.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 from loguru import logger
 
+from openjudge.evaluation_strategy import BaseEvaluationStrategy
 from openjudge.graders.base_grader import GraderError, GraderMode, GraderRank
 from openjudge.graders.llm_grader import LLMGrader
 from openjudge.models.base_chat_model import BaseChatModel
@@ -59,8 +60,8 @@ b. If information is incomplete, should clearly state missing parts and suggest 
 <Output Schema>
 Please output your assessment in the following JSON format strictly:
 {{
-    "rank": <[1, 2] or [2, 1]>,
-    "reason": "<detailed explanation of your evaluation reasoning, including performance comparison under each evaluation criterion>"
+    "reason": "<detailed explanation of your evaluation reasoning, including performance comparison under each evaluation criterion>",
+    "rank": <[1, 2] or [2, 1]>
 }}
 </Output Schema>
 
@@ -110,8 +111,8 @@ b. 若信息不全，应明确说明缺失部分并提示可能的来源或查�
 <输出格式>
 请按以下结构化 JSON 格式严格输出你的评估：
 {{
-    "rank": <[1, 2] 或 [2, 1]>,
-    "reason": "<详细解释你的评估理由，包括在各个评估标准下的表现对比>"
+    "reason": "<详细解释你的评估理由，包括在各个评估标准下的表现对比>",
+    "rank": <[1, 2] 或 [2, 1]>
 }}
 </输出格式>
 
@@ -191,6 +192,7 @@ class SearchIntegrityGrader(LLMGrader):
         model: BaseChatModel | dict,
         template: Optional[PromptTemplate] = None,
         language: LanguageEnum = LanguageEnum.ZH,
+        strategy: BaseEvaluationStrategy | None = None,
     ):
         """
         Initialize SearchIntegrityGrader.
@@ -207,6 +209,7 @@ class SearchIntegrityGrader(LLMGrader):
             model=model,
             template=template or DEFAULT_SEARCH_INTEGRITY_TEMPLATE,
             language=language,
+            strategy=strategy,
         )
 
     async def _aevaluate(
@@ -227,6 +230,13 @@ class SearchIntegrityGrader(LLMGrader):
 
         Returns:
             GraderRank: Rank result with [1, 2] if answer_1 is better, [2, 1] if answer_2 is better
+
+        Example:
+            >>> result = await grader.aevaluate(
+            ...     query="搜索新能源汽车相关股票",
+            ...     answer_1="比亚迪是新能源汽车股票。",
+            ...     answer_2="新能源汽车板块主要标的：比亚迪、宁德时代、长城汽车..."
+            ... )
         """
         try:
             result = await super()._aevaluate(

--- a/cookbooks/finance_grader/stock_search/search_timeliness.py
+++ b/cookbooks/finance_grader/stock_search/search_timeliness.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 from loguru import logger
 
+from openjudge.evaluation_strategy import BaseEvaluationStrategy
 from openjudge.graders.base_grader import GraderError, GraderMode, GraderRank
 from openjudge.graders.llm_grader import LLMGrader
 from openjudge.models.base_chat_model import BaseChatModel
@@ -59,8 +60,8 @@ b. For facts with obvious timeliness (such as tariff agreement effective dates, 
 <Output Schema>
 Please output your assessment in the following JSON format strictly:
 {{
-    "rank": <[1, 2] or [2, 1]>,
-    "reason": "<detailed explanation of your evaluation reasoning, including performance comparison under each evaluation criterion>"
+    "reason": "<detailed explanation of your evaluation reasoning, including performance comparison under each evaluation criterion>",
+    "rank": <[1, 2] or [2, 1]>
 }}
 </Output Schema>
 
@@ -110,8 +111,8 @@ b. 对有明显时效性的事实（如关税协议生效日期、近期产能�
 <输出格式>
 请按以下结构化 JSON 格式严格输出你的评估：
 {{
-    "rank": <[1, 2] 或 [2, 1]>,
-    "reason": "<详细解释你的评估理由，包括在各个评估标准下的表现对比>"
+    "reason": "<详细解释你的评估理由，包括在各个评估标准下的表现对比>",
+    "rank": <[1, 2] 或 [2, 1]>
 }}
 </输出格式>
 
@@ -191,6 +192,7 @@ class SearchTimelinessGrader(LLMGrader):
         model: BaseChatModel | dict,
         template: Optional[PromptTemplate] = None,
         language: LanguageEnum = LanguageEnum.ZH,
+        strategy: BaseEvaluationStrategy | None = None,
     ):
         """
         Initialize SearchTimelinessGrader.
@@ -207,6 +209,7 @@ class SearchTimelinessGrader(LLMGrader):
             model=model,
             template=template or DEFAULT_SEARCH_TIMELINESS_TEMPLATE,
             language=language,
+            strategy=strategy,
         )
 
     async def _aevaluate(
@@ -227,6 +230,13 @@ class SearchTimelinessGrader(LLMGrader):
 
         Returns:
             GraderRank: Rank result with [1, 2] if answer_1 is better, [2, 1] if answer_2 is better
+
+        Example:
+            >>> result = await grader.aevaluate(
+            ...     query="查询最新的新能源汽车销量数据",
+            ...     answer_1="新能源汽车销量增长。",
+            ...     answer_2="2024年1月新能源汽车销量72.9万辆，同比增长78.8%..."
+            ... )
         """
         try:
             result = await super()._aevaluate(


### PR DESCRIPTION
- Add event_interpretation graders (event_analysis, event_identification)
- Add industry_research graders (characteristics_analysis, risk_analysis, underlying_comparison)
- Add macro_analysis graders (concept_explanation, macro_analysis)
- Add stock_analysis graders (fundamental_analysis, overall_logic, stock_risk_analysis, valuation_analysis)
- Add stock_search graders (search_integrity, search_relevance, search_timeliness)

All graders follow the new prompt template format and openjudge interface.

## OpenJudge Version

[The version of OpenJudge you are working on, e.g. `import openjudge; print(openjudge.__version__)`]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review