### PR TITLE
feat(voting): add configurable tie-breaker strategy

### DIFF
--- a/openjudge/evaluation_strategy/__init__.py
+++ b/openjudge/evaluation_strategy/__init__.py
@@ -3,11 +3,19 @@
 from .average_evaluation_strategy import AverageEvaluationStrategy
 from .base_evaluation_strategy import BaseEvaluationStrategy
 from .direct_evaluation_strategy import DirectEvaluationStrategy
-from .voting_evaluation_strategy import VotingEvaluationStrategy
+from .voting_evaluation_strategy import (
+    CLOSEST_TO_MEAN,
+    MAX,
+    MIN,
+    VotingEvaluationStrategy,
+)
 
 __all__ = [
     "BaseEvaluationStrategy",
+    "CLOSEST_TO_MEAN",
     "DirectEvaluationStrategy",
+    "MAX",
+    "MIN",
     "VotingEvaluationStrategy",
     "AverageEvaluationStrategy",
 ]

--- a/tests/evaluation_strategy/test_voting_evaluation_strategy.py
+++ b/tests/evaluation_strategy/test_voting_evaluation_strategy.py
@@ -7,6 +7,9 @@ correctly according to the specifications.
 import pytest
 
 from openjudge.evaluation_strategy.voting_evaluation_strategy import (
+    CLOSEST_TO_MEAN,
+    MAX,
+    MIN,
     VotingEvaluationStrategy,
 )
 from openjudge.graders.schema import GraderError, GraderScore
@@ -23,8 +26,8 @@ class TestVotingEvaluationStrategy:
 
     def test_initialization_valid_tie_breaker(self):
         """Test successful initialization with valid tie_breaker."""
-        strategy = VotingEvaluationStrategy(num_votes=3, tie_breaker="max")
-        assert strategy.tie_breaker == "max"
+        strategy = VotingEvaluationStrategy(num_votes=3, tie_breaker=MAX)
+        assert strategy.tie_breaker == MAX
 
         strategy_with_callable = VotingEvaluationStrategy(
             num_votes=3,
@@ -41,13 +44,13 @@ class TestVotingEvaluationStrategy:
         """Test initialization raises error with invalid tie_breaker."""
         with pytest.raises(
             ValueError,
-            match="tie_breaker must be one of {'min', 'max', 'mean_closest'} or a callable",
+            match="tie_breaker must be one of .* or a callable",
         ):
             VotingEvaluationStrategy(num_votes=3, tie_breaker="median")
 
         with pytest.raises(
             ValueError,
-            match="tie_breaker must be one of {'min', 'max', 'mean_closest'} or a callable",
+            match="tie_breaker must be one of .* or a callable",
         ):
             VotingEvaluationStrategy(num_votes=3, tie_breaker=123)  # type: ignore[arg-type]
 
@@ -141,7 +144,7 @@ class TestVotingEvaluationStrategy:
     @pytest.mark.asyncio
     async def test_execute_tie_breaker_min(self):
         """Test tie is resolved by choosing lower score with tie_breaker=min."""
-        strategy = VotingEvaluationStrategy(num_votes=5, tie_breaker="min")
+        strategy = VotingEvaluationStrategy(num_votes=5, tie_breaker=MIN)
         scores = [1.0, 3.0, 5.0, 5.0, 3.0]
         call_count = 0
 
@@ -157,7 +160,7 @@ class TestVotingEvaluationStrategy:
     @pytest.mark.asyncio
     async def test_execute_tie_breaker_max(self):
         """Test tie is resolved by choosing higher score with tie_breaker=max."""
-        strategy = VotingEvaluationStrategy(num_votes=5, tie_breaker="max")
+        strategy = VotingEvaluationStrategy(num_votes=5, tie_breaker=MAX)
         scores = [1.0, 3.0, 5.0, 5.0, 3.0]
         call_count = 0
 
@@ -171,9 +174,9 @@ class TestVotingEvaluationStrategy:
         assert result.score == 5.0
 
     @pytest.mark.asyncio
-    async def test_execute_tie_breaker_mean_closest(self):
+    async def test_execute_tie_breaker_closest_to_mean(self):
         """Test tie is resolved by choosing score closest to mean."""
-        strategy = VotingEvaluationStrategy(num_votes=5, tie_breaker="mean_closest")
+        strategy = VotingEvaluationStrategy(num_votes=5, tie_breaker=CLOSEST_TO_MEAN)
         scores = [1.0, 3.0, 5.0, 5.0, 3.0]
         call_count = 0
 


### PR DESCRIPTION
## Description

This PR includes the first two commits on `voting-tiebreaker` and introduces
configurable tie-breaking for `VotingEvaluationStrategy`, plus corresponding
unit test coverage.

### Background and purpose

`VotingEvaluationStrategy` had a fixed tie resolution behavior. This PR makes
tie-breaking configurable and verifies each supported strategy and error path.

### Changes made

- Added configurable `tie_breaker` support in `VotingEvaluationStrategy`:
  - `min`
  - `max`
  - `mean_closest`
  - custom callable
- Refactored tie-breaker validation to remove duplicated checks.
- Added tests for:
  - valid/invalid `tie_breaker` initialization
  - tie behavior for each built-in strategy
  - custom callable behavior and invalid callable return value

### Included commits

- `8077a0e` feat(voting): add configurable tie-breaker
- `0ee4f24` test(voting): add tie-breaker strategy tests

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `pre-commit run --all-files` command
- [x]  All tests are passing
- [x]  Docstrings are in Google style
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
