### PR TITLE
fix(docs): bump pymdown-extensions for MkDocs build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,7 +7,8 @@ mkdocstrings==0.30.1
 mkdocstrings-python==1.18.2
 
 # Markdown extensions (pymdownx is included in pymdown-extensions)
-pymdown-extensions==10.16.1
+# 10.21.2+ fixes Highlight + Pygments when code-block title/filename is None (mkdocs build crash).
+pymdown-extensions>=10.21.2,<11
 
 # Syntax highlighting
 Pygments>=2.18.0

--- a/openjudge/runner/grading_runner.py
+++ b/openjudge/runner/grading_runner.py
@@ -191,9 +191,7 @@ class GradingRunner(BaseRunner):
         self.show_progress = show_progress
         self.executor = executor or SemaphoreResourceExecutor(max_concurrency)
         self.enable_timing = enable_timing or timing_collector is not None
-        self.timing_collector = timing_collector or (
-            TimingCollector() if self.enable_timing else None
-        )
+        self.timing_collector = timing_collector or (TimingCollector() if self.enable_timing else None)
 
         # Handle aggregators
         if not aggregators:
@@ -438,10 +436,7 @@ class GradingRunner(BaseRunner):
                     grader_results[aggregator_name] = [None] * len(dataset)
                     for i in range(len(dataset)):
                         grader_results[aggregator_name][i] = aggregator(
-                            {
-                                grader_name: grader_results[grader_name][i]
-                                for grader_name in self.grader_configs.keys()
-                            },
+                            {grader_name: grader_results[grader_name][i] for grader_name in self.grader_configs.keys()},
                         )
             return grader_results
 


### PR DESCRIPTION
pymdown-extensions 10.21.2 fixes Highlight passing None as Pygments filename/title, which caused AttributeError in html.escape on CI.

Refs: https://facelessuser.github.io/pymdown-extensions/about/changelog/
Made-with: Cursor

## OpenJudge Version

[The version of OpenJudge you are working on, e.g. `import openjudge; print(openjudge.__version__)`]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review