### PR TITLE
docs: fix Skill Graders table and add skills to nav

### DIFF
--- a/docs/built_in_graders/overview.md
+++ b/docs/built_in_graders/overview.md
@@ -168,7 +168,7 @@ Evaluate vision-language tasks and image quality. [→ Detailed Documentation](m
 Evaluate AI Agent Skill packages across security, design, and task-fit dimensions. [→ Detailed Documentation](skills.md)
 
 || Grader | Description | Type | Score Range |
-|||--------|-------------|------|-------------|
+||--------|-------------|------|-------------|
 || `SkillThreatAnalysisGrader` | Security threat scanner using AITech taxonomy | LLM-Based | 1-4 |
 || `SkillDeclarationAlignmentGrader` | Detects mismatches between declared and actual behavior | LLM-Based | 1-3 |
 || `SkillCompletenessGrader` | Checks if skill provides sufficient detail to act on | LLM-Based | 1-3 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,6 +137,16 @@ It can also convert grading results into **reward signals** to help you **fine-t
     </p>
   </a>
 
+  <a href="built_in_graders/skills/" class="feature-card">
+    <div class="card-header">
+      <img src="https://unpkg.com/lucide-static@latest/icons/shield-check.svg" class="card-icon card-icon-agent">
+      <h3>Skill</h3>
+    </div>
+    <p class="card-desc">
+      Evaluate AI Agent Skill packages across security, design, and task-fit dimensions. Assess threat analysis, declaration alignment, completeness, relevance, and structural design quality.
+    </p>
+  </a>
+
 </div>
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
       - Code & Math Graders: built_in_graders/code_math.md
       - Text Graders: built_in_graders/text.md
       - Format Graders: built_in_graders/format.md
+      - Skill Graders: built_in_graders/skills.md
 
   - Building Graders:
       - Overview: building_graders/overview.md


### PR DESCRIPTION
- Fix markdown table separator row in built_in_graders/overview.md
- Add Skill Graders to mkdocs.yml navigation
- Add Skill card to docs index Built-in Graders section

Made-with: Cursor

## OpenJudge Version

[The version of OpenJudge you are working on, e.g. `import openjudge; print(openjudge.__version__)`]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review