### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/skills/mmx-cli/SKILL.md
+++ b/skills/mmx-cli/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: mmx-cli
+description: >
+  Generate text, images, video, speech, and music via the MiniMax AI platform.
+  Covers text generation (MiniMax-M2.7 model), image generation (image-01),
+  video generation (Hailuo-2.3), speech synthesis (speech-2.8-hd, 300+ voices),
+  music generation (music-2.6 with lyrics, cover, and instrumental), and web search.
+  Use when the user needs to create AI-generated multimedia content, produce
+  narrated audio from text, compose music, or search the web through MiniMax AI services.
+---
+
+# mmx-cli Skill
+
+Generate multimedia content (text, images, video, speech, music) via the
+[MiniMax AI](https://github.com/MiniMax-AI/cli) platform.
+
+## Install
+
+```bash
+npx skills add MiniMax-AI/cli@skill -g -y
+```
+
+Or manually:
+
+```bash
+npm install -g @minimax-ai/cli
+```
+
+Set your API key:
+
+```bash
+export MINIMAX_API_KEY=your_api_key_here
+```
+
+## Capabilities
+
+| Capability | Command | Model |
+|------------|---------|-------|
+| Text generation | `mmx text generate` | MiniMax-M2.7 |
+| Image generation | `mmx image generate` | image-01 |
+| Video generation | `mmx video generate` | Hailuo-2.3 |
+| Speech synthesis | `mmx speech generate` | speech-2.8-hd |
+| Music generation | `mmx music generate` | music-2.6 |
+| Web search | `mmx search` | — |
+
+## Quick Examples
+
+```bash
+# Generate text
+mmx text generate "Summarize the key benefits of reinforcement learning"
+
+# Generate an image
+mmx image generate "A futuristic city skyline at sunset, photorealistic"
+
+# Generate a short video clip
+mmx video generate "A golden retriever playing in autumn leaves"
+
+# Synthesize speech from text
+mmx speech generate --text "Hello, welcome to the demo." --voice Calm_Woman
+
+# Generate music with lyrics
+mmx music generate --lyrics "Rise and shine, a brand new day" --style "pop upbeat"
+
+# Web search
+mmx search "latest advances in LLM evaluation"
+```
+
+## Gather from user before running
+
+| Info | Required? | Notes |
+|------|-----------|-------|
+| MINIMAX_API_KEY | Yes | From [MiniMax platform](https://www.minimaxi.com/) |
+| Prompt or text | Yes | Describe what to generate |
+| Voice name | No | For speech; run `mmx speech list-voices` to browse 300+ options |
+| Output path | No | Default saves to current directory |
+
+## Tips
+
+- Use `--output json` flag for structured output suitable for pipelines.
+- Use `--non-interactive` and `--quiet` flags in automated / agent workflows.
+- Run `mmx --help` or `mmx <subcommand> --help` to see all options.
+- The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md)
+  in the upstream repo is always up-to-date with the latest flags and models.


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` (`skill/` path) to `skills/mmx-cli/SKILL.md` so the mmx-cli skill is discoverable via [openjudge.me/skills](https://openjudge.me/skills) and the `npx skills` CLI
- Users can install via `npx skills add MiniMax-AI/cli@skill -g -y` — the SKILL.md is fetched directly from [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md)
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**1 new file, 83 lines.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard and includes agent-specific flags (`--non-interactive`, `--quiet`, `--output json`).

## Test plan

- `npx skills find mmx-cli` lists the mmx-cli skill
- `npx skills add MiniMax-AI/cli@skill -g -y` installs successfully
- Ask agent "generate a jazz instrumental" — agent invokes `mmx music generate` via terminal