### PR TITLE
feat: add Qiniu provider support

### DIFF
--- a/openjudge/models/__init__.py
+++ b/openjudge/models/__init__.py
@@ -6,11 +6,13 @@ Model integrations module from AgentScope
 from openjudge.models.base_chat_model import BaseChatModel
 from openjudge.models.minimax_chat_model import MiniMaxChatModel
 from openjudge.models.openai_chat_model import OpenAIChatModel
+from openjudge.models.qiniu_chat_model import QiniuChatModel
 from openjudge.models.qwen_vl_model import QwenVLModel
 
 __all__ = [
     "BaseChatModel",
     "MiniMaxChatModel",
     "OpenAIChatModel",
+    "QiniuChatModel",
     "QwenVLModel",
 ]

--- a/openjudge/models/qiniu_chat_model.py
+++ b/openjudge/models/qiniu_chat_model.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""Qiniu Chat Model."""
+
+import os
+from typing import Any, Dict
+
+from openjudge.models.openai_chat_model import OpenAIChatModel
+
+# Qiniu-supported default model list
+QINIU_MODELS = [
+    "deepseek-v3",
+]
+
+
+class QiniuChatModel(OpenAIChatModel):
+    """Qiniu chat model using the OpenAI-compatible API gateway."""
+
+    QINIU_BASE_URL = "https://api.qnaigc.com/v1"
+
+    def __init__(
+        self,
+        model: str = "deepseek-v3",
+        api_key: str | None = None,
+        base_url: str | None = None,
+        stream: bool = False,
+        client_args: Dict[str, Any] | None = None,
+        max_retries: int | None = None,
+        timeout: float | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the qiniu chat model."""
+        resolved_api_key = api_key or os.getenv("QINIU_API_KEY")
+        resolved_base_url = base_url or self.QINIU_BASE_URL
+
+        super().__init__(
+            model=model,
+            api_key=resolved_api_key,
+            base_url=resolved_base_url,
+            stream=stream,
+            client_args=client_args,
+            max_retries=max_retries,
+            timeout=timeout,
+            **kwargs,
+        )
+
+
+__all__ = ["QiniuChatModel", "QINIU_MODELS"]

--- a/tests/models/test_qiniu_chat_model.py
+++ b/tests/models/test_qiniu_chat_model.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Unit tests for QiniuChatModel."""
+
+import pytest
+
+from openjudge.models import QiniuChatModel
+from openjudge.models.qiniu_chat_model import QINIU_MODELS
+
+
+@pytest.mark.unit
+class TestQiniuChatModelInit:
+    """Verify constructor defaults and argument handling."""
+
+    def test_default_base_url(self):
+        model = QiniuChatModel(api_key="test-key")
+        assert model.client.base_url is not None
+        assert "qnaigc.com" in str(model.client.base_url)
+
+    def test_default_model(self):
+        model = QiniuChatModel(api_key="test-key")
+        assert model.model == "deepseek-v3"
+
+    def test_qiniu_models_contains_deepseek_v3(self):
+        assert "deepseek-v3" in QINIU_MODELS
+
+    def test_api_key_from_env(self, monkeypatch):
+        monkeypatch.setenv("QINIU_API_KEY", "env-key-123")
+        model = QiniuChatModel()
+        assert model.client.api_key == "env-key-123"
+
+    def test_explicit_api_key_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("QINIU_API_KEY", "env-key")
+        model = QiniuChatModel(api_key="explicit-key")
+        assert model.client.api_key == "explicit-key"
+
+    def test_custom_base_url(self):
+        model = QiniuChatModel(api_key="k", base_url="https://custom.qnaigc.com/v1")
+        assert "custom.qnaigc.com" in str(model.client.base_url)
+
+
+@pytest.mark.unit
+class TestQiniuChatModelInheritance:
+    """Verify class hierarchy and exported symbols."""
+
+    def test_inherits_from_openai_chat_model(self):
+        from openjudge.models.openai_chat_model import OpenAIChatModel
+
+        assert issubclass(QiniuChatModel, OpenAIChatModel)
+
+    def test_exported_from_models_package(self):
+        from openjudge.models import QiniuChatModel as Imported
+
+        assert Imported is QiniuChatModel

--- a/ui/shared/constants.py
+++ b/ui/shared/constants.py
@@ -20,6 +20,7 @@ DEFAULT_API_ENDPOINTS: dict[str, str] = {
     "DashScope": "https://dashscope.aliyuncs.com/compatible-mode/v1",
     "OpenAI": "https://api.openai.com/v1",
     "DeepSeek": "https://api.deepseek.com/v1",
+    "Qiniu": "https://api.qnaigc.com/v1",
     "Custom": "",
 }
 
@@ -39,6 +40,7 @@ DEFAULT_MODELS: list[str] = [
     "o3-mini",
     "o4-mini",
     # DeepSeek
+    "deepseek-v3",
     "deepseek-v3.2",
     "deepseek-r1",
 ]


### PR DESCRIPTION
## Summary
Added support for Qiniu AI (七牛云) as a new model provider.

## What changed

- `ui/shared/constants.py` - Added a default API address for Qiniu and supplemented the default deepseek-v3 model, allowing the UI to directly select the Qiniu channel configuration.

- `tests/models/test_qiniu_chat_model.py` - Added unit tests for QiniuChatModel to verify default values, environment variable key retrieval, parameter overriding, and inheritance/export behavior.

- `openjudge/models/qiniu_chat_model.py` - The QiniuChatModel (based on the OpenAI compatible interface) and QINIU_MODELS have been added to encapsulate the default model, default address, and API Key reading logic of the Qiniu gateway.

- `openjudge/models/__init__.py` - Register QiniuChatModel to the model package export list to support unified import from openjudge.models.

## Testing
```
pytest tests/models/test_qiniu_chat_model.py 		# 8 passed, 0 failed
```

