### PR TITLE
fix(graders): avoid KeyError when LLM output misses score/reason fields

### DIFF
--- a/openjudge/graders/llm_grader.py
+++ b/openjudge/graders/llm_grader.py
@@ -337,8 +337,8 @@ class LLMGrader(BaseGrader):
         parsed = getattr(chat_response, "parsed", {}) or {}
 
         if self.mode == GraderMode.LISTWISE:
-            rank = parsed.pop("rank")
-            reason = parsed.pop("reason")
+            rank = parsed.pop("rank", [])
+            reason = parsed.pop("reason", "")
             result = GraderRank(
                 name=self.name,
                 rank=rank,  # type: ignore
@@ -346,8 +346,8 @@ class LLMGrader(BaseGrader):
                 metadata=parsed,  # type: ignore
             )
         elif self.mode == GraderMode.POINTWISE:
-            score = parsed.pop("score")
-            reason = str(parsed.pop("reason"))
+            score = parsed.pop("score", 0)
+            reason = str(parsed.pop("reason", ""))
             result = GraderScore(
                 name=self.name,
                 score=score,  # type: ignore


### PR DESCRIPTION
## OpenJudge Version

[The version of OpenJudge you are working on, e.g. `import openjudge; print(openjudge.__version__)`]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `pre-commit run --all-files` command
- [ ]  All tests are passing
- [ ]  Docstrings are in Google style
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review