### PR TITLE
fix: preserve user-provided enable_thinking for Qwen models

### DIFF
--- a/openjudge/models/openai_chat_model.py
+++ b/openjudge/models/openai_chat_model.py
@@ -214,7 +214,8 @@ class OpenAIChatModel(BaseChatModel):
         if not self.stream and ("qwen" in self.model.lower() or "pai-judge" in self.model.lower()):
             if "extra_body" not in kwargs:
                 kwargs["extra_body"] = {}
-            kwargs["extra_body"]["enable_thinking"] = False
+            if "enable_thinking" not in kwargs["extra_body"]:
+                kwargs["extra_body"]["enable_thinking"] = False
 
         # Add tools and tool_choice to kwargs if provided
         if tools:

--- a/tests/models/test_openai_chat_model.py
+++ b/tests/models/test_openai_chat_model.py
@@ -297,6 +297,77 @@ class TestOpenAIChatModel:
             "data:;base64,",
         )
 
+    @patch("openjudge.models.openai_chat_model.AsyncOpenAI")
+    def test_qwen_enable_thinking_user_value_preserved(self, mock_async_openai):
+        """Test that user-provided enable_thinking in extra_body is not overwritten for Qwen models."""
+        mock_instance = mock_async_openai.return_value
+        mock_instance.chat.completions.create = AsyncMock(
+            return_value=ChatCompletion(
+                id="test-id",
+                choices=[
+                    Choice(
+                        finish_reason="stop",
+                        index=0,
+                        message=ChatCompletionMessage(content="OK", role="assistant"),
+                    ),
+                ],
+                created=1234567890,
+                model="qwen3-32b",
+                object="chat.completion",
+            )
+        )
+
+        with patch("openjudge.models.openai_chat_model.AsyncOpenAI") as mock_ctor:
+            mock_ctor.return_value = mock_instance
+            model = OpenAIChatModel(
+                model="qwen3-32b",
+                api_key="test-key",
+                base_url="https://api.openai.com/v1",
+                extra_body={"enable_thinking": True},
+            )
+
+            messages = [{"role": "user", "content": "Hello"}]
+            asyncio.run(model.achat(messages=messages))
+
+            call_kwargs = mock_instance.chat.completions.create.call_args[1]
+            # User's value should be preserved
+            assert call_kwargs["extra_body"]["enable_thinking"] is True
+
+    @patch("openjudge.models.openai_chat_model.AsyncOpenAI")
+    def test_qwen_enable_thinking_default_when_not_provided(self, mock_async_openai):
+        """Test that enable_thinking defaults to False for Qwen models when not provided."""
+        mock_instance = mock_async_openai.return_value
+        mock_instance.chat.completions.create = AsyncMock(
+            return_value=ChatCompletion(
+                id="test-id",
+                choices=[
+                    Choice(
+                        finish_reason="stop",
+                        index=0,
+                        message=ChatCompletionMessage(content="OK", role="assistant"),
+                    ),
+                ],
+                created=1234567890,
+                model="qwen3-32b",
+                object="chat.completion",
+            )
+        )
+
+        with patch("openjudge.models.openai_chat_model.AsyncOpenAI") as mock_ctor:
+            mock_ctor.return_value = mock_instance
+            model = OpenAIChatModel(
+                model="qwen3-32b",
+                api_key="test-key",
+                base_url="https://api.openai.com/v1",
+            )
+
+            messages = [{"role": "user", "content": "Hello"}]
+            asyncio.run(model.achat(messages=messages))
+
+            call_kwargs = mock_instance.chat.completions.create.call_args[1]
+            # Default should be False
+            assert call_kwargs["extra_body"]["enable_thinking"] is False
+
     @pytest.mark.parametrize(
         "init_kwargs, expected_in_call, not_expected_in_call",
         [


### PR DESCRIPTION
## Summary

When users explicitly set `enable_thinking` via `extra_body` in `OpenAIChatModel`, the value was being forcibly overwritten to `False` for Qwen/pai-judge models in non-streaming mode.

This PR adds a guard to only set the default when the user hasn't already configured it:

```python
# Before: always overwrites
kwargs["extra_body"]["enable_thinking"] = False

# After: respects user configuration
if "enable_thinking" not in kwargs["extra_body"]:
    kwargs["extra_body"]["enable_thinking"] = False
```

## Changes
- **openjudge/models/openai_chat_model.py**: Added conditional check before setting `enable_thinking` default
- **tests/models/test_openai_chat_model.py**: Added 2 unit tests:
  - `test_qwen_enable_thinking_user_value_preserved`: verifies user-provided values are kept
  - `test_qwen_enable_thinking_default_when_not_provided`: verifies default False still applies

## Motivation
Related to issue [#85](https://github.com/agentscope-ai/OpenJudge/issues/85) where users reported unexpected WARNING/DEBUG output when configuring Qwen models. The root cause was that user-provided `extra_body` settings were being silently overwritten.

---
Powered by Hermes Agent | Building open source daily 🚀