### PR TITLE
feat(models): upgrade MiniMax provider to M3 as default

### DIFF
--- a/cookbooks/auto_arena/examples/config.yaml
+++ b/cookbooks/auto_arena/examples/config.yaml
@@ -158,12 +158,12 @@ target_endpoints:
       temperature: 0.7
       max_tokens: 2048
 
-  # Example: MiniMax M2.7 as candidate
+  # Example: MiniMax M3 as candidate
   # Get your API key at https://www.minimax.io/
   minimax_candidate:
     base_url: "https://api.minimax.io/v1"
     api_key: "${MINIMAX_API_KEY}"
-    model: "MiniMax-M2.7"
+    model: "MiniMax-M3"
     system_prompt: "You are a professional English-Chinese translator. Provide accurate and fluent translations."
     extra_params:
       temperature: 0.7

--- a/openjudge/models/minimax_chat_model.py
+++ b/openjudge/models/minimax_chat_model.py
@@ -13,10 +13,9 @@ from openjudge.models.schema.oai.response import ChatResponse
 
 # MiniMax-supported models with 204K context window
 MINIMAX_MODELS = [
+    "MiniMax-M3",
     "MiniMax-M2.7",
     "MiniMax-M2.7-highspeed",
-    "MiniMax-M2.5",
-    "MiniMax-M2.5-highspeed",
 ]
 
 _THINK_TAG_RE = re.compile(r"<think>.*?</think>", re.DOTALL)
@@ -31,10 +30,9 @@ class MiniMaxChatModel(OpenAIChatModel):
     """MiniMax chat model, using the OpenAI-compatible API at api.minimax.io.
 
     Supported models (all with 204K context window):
-        - ``MiniMax-M2.7`` — latest generation, best quality
-        - ``MiniMax-M2.7-highspeed`` — latest generation, faster inference
-        - ``MiniMax-M2.5`` — previous generation
-        - ``MiniMax-M2.5-highspeed`` — previous generation, faster inference
+        - ``MiniMax-M3`` — latest generation, best quality (default)
+        - ``MiniMax-M2.7`` — previous generation
+        - ``MiniMax-M2.7-highspeed`` — previous generation, faster inference
 
     .. note::
         MiniMax requires ``temperature`` to be in the range ``(0.0, 1.0]``.
@@ -45,7 +43,7 @@ class MiniMaxChatModel(OpenAIChatModel):
         >>> from openjudge.models import MiniMaxChatModel
         >>> from openjudge.graders.common.correctness import CorrectnessGrader
         >>>
-        >>> model = MiniMaxChatModel(model="MiniMax-M2.7")
+        >>> model = MiniMaxChatModel(model="MiniMax-M3")
         >>> grader = CorrectnessGrader(model=model)
         >>> result = asyncio.run(grader.aevaluate(
         ...     query="What is the capital of France?",
@@ -59,7 +57,7 @@ class MiniMaxChatModel(OpenAIChatModel):
 
     def __init__(
         self,
-        model: str = "MiniMax-M2.7",
+        model: str = "MiniMax-M3",
         api_key: str | None = None,
         base_url: str | None = None,
         stream: bool = False,
@@ -71,9 +69,9 @@ class MiniMaxChatModel(OpenAIChatModel):
         """Initialize the MiniMax chat model.
 
         Args:
-            model: MiniMax model name. Defaults to ``"MiniMax-M2.7"``.
-                Available models: ``MiniMax-M2.7``, ``MiniMax-M2.7-highspeed``,
-                ``MiniMax-M2.5``, ``MiniMax-M2.5-highspeed``.
+            model: MiniMax model name. Defaults to ``"MiniMax-M3"``.
+                Available models: ``MiniMax-M3``, ``MiniMax-M2.7``,
+                ``MiniMax-M2.7-highspeed``.
             api_key: MiniMax API key. Falls back to the ``MINIMAX_API_KEY``
                 environment variable.
             base_url: API base URL. Defaults to ``https://api.minimax.io/v1``.
@@ -118,7 +116,7 @@ class MiniMaxChatModel(OpenAIChatModel):
         Wraps :meth:`OpenAIChatModel.achat` with MiniMax-specific adjustments:
 
         * ``temperature`` values outside ``(0.0, 1.0]`` are clamped.
-        * ``<think>…</think>`` reasoning blocks produced by M2.5/M2.7 models
+        * ``<think>…</think>`` reasoning blocks produced by M2.7/M3 models
           are stripped from non-streaming responses so downstream graders always
           receive clean text.
 

--- a/skills/mmx-cli/SKILL.md
+++ b/skills/mmx-cli/SKILL.md
@@ -2,7 +2,7 @@
 name: mmx-cli
 description: >
   Generate text, images, video, speech, and music via the MiniMax AI platform.
-  Covers text generation (MiniMax-M2.7 model), image generation (image-01),
+  Covers text generation (MiniMax-M3 model), image generation (image-01),
   video generation (Hailuo-2.3), speech synthesis (speech-2.8-hd, 300+ voices),
   music generation (music-2.6 with lyrics, cover, and instrumental), and web search.
   Use when the user needs to create AI-generated multimedia content, produce
@@ -36,7 +36,7 @@ export MINIMAX_API_KEY=your_api_key_here
 
 | Capability | Command | Model |
 |------------|---------|-------|
-| Text generation | `mmx text generate` | MiniMax-M2.7 |
+| Text generation | `mmx text generate` | MiniMax-M3 |
 | Image generation | `mmx image generate` | image-01 |
 | Video generation | `mmx video generate` | Hailuo-2.3 |
 | Speech synthesis | `mmx speech generate` | speech-2.8-hd |

--- a/tests/models/test_minimax_chat_model.py
+++ b/tests/models/test_minimax_chat_model.py
@@ -47,11 +47,11 @@ class TestMiniMaxChatModelInit:
 
     def test_default_model(self):
         model = MiniMaxChatModel(api_key="test-key")
-        assert model.model == "MiniMax-M2.7"
+        assert model.model == "MiniMax-M3"
 
     def test_custom_model(self):
-        model = MiniMaxChatModel(model="MiniMax-M2.5", api_key="test-key")
-        assert model.model == "MiniMax-M2.5"
+        model = MiniMaxChatModel(model="MiniMax-M2.7", api_key="test-key")
+        assert model.model == "MiniMax-M2.7"
 
     def test_all_supported_models(self):
         for name in MINIMAX_MODELS:
@@ -221,7 +221,10 @@ class TestMiniMaxChatModelInheritance:
         assert Imported is MiniMaxChatModel
 
     def test_minimax_models_list_not_empty(self):
-        assert len(MINIMAX_MODELS) >= 4
+        assert len(MINIMAX_MODELS) >= 3
+
+    def test_minimax_models_contain_m3(self):
+        assert "MiniMax-M3" in MINIMAX_MODELS
 
     def test_minimax_models_contain_m27(self):
         assert "MiniMax-M2.7" in MINIMAX_MODELS
@@ -245,7 +248,7 @@ class TestMiniMaxChatModelIntegration:
 
     @pytest.mark.asyncio
     async def test_basic_chat(self):
-        model = MiniMaxChatModel(model="MiniMax-M2.7")
+        model = MiniMaxChatModel(model="MiniMax-M3")
         response = await model.achat(messages=[{"role": "user", "content": "Reply with the single word: hello"}])
         assert isinstance(response, ChatResponse)
         assert response.content
@@ -254,7 +257,7 @@ class TestMiniMaxChatModelIntegration:
 
     @pytest.mark.asyncio
     async def test_temperature_clamping_does_not_error(self):
-        model = MiniMaxChatModel(model="MiniMax-M2.7", temperature=0.0)
+        model = MiniMaxChatModel(model="MiniMax-M3", temperature=0.0)
         response = await model.achat(messages=[{"role": "user", "content": "Say: ok"}])
         assert isinstance(response, ChatResponse)
 


### PR DESCRIPTION
## OpenJudge Version

`0.2.0`

## Description

Upgrade the `MiniMaxChatModel` provider to use the new **MiniMax-M3** as the default model, while keeping `M2.7` / `M2.7-highspeed` available as alternatives. The older `M2.5` / `M2.5-highspeed` entries are removed from the supported list.

### Changes

- `openjudge/models/minimax_chat_model.py`
  - `MINIMAX_MODELS` now lists `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed` (M3 first).
  - Default `model` parameter changed from `MiniMax-M2.7` to `MiniMax-M3`.
  - Docstring example and supported-models block updated accordingly.
- `tests/models/test_minimax_chat_model.py`
  - `test_default_model` now expects `MiniMax-M3`.
  - `test_custom_model` uses `MiniMax-M2.7` (was `M2.5`).
  - New `test_minimax_models_contain_m3`; list-length assertion relaxed to `>= 3`.
  - Integration tests run against `MiniMax-M3`.
- `skills/mmx-cli/SKILL.md`
  - Text-generation entry bumped to `MiniMax-M3`.
- `cookbooks/auto_arena/examples/config.yaml`
  - Example MiniMax candidate model upgraded to `MiniMax-M3`.

The OpenAI-compatible base URL (`https://api.minimax.io/v1`), temperature clamping, `<think>` stripping, and the rest of the model logic are unchanged.

### How to test

```bash
pytest tests/models/test_minimax_chat_model.py -m unit -v
```

All 26 unit tests in this file pass locally; the wider `tests/models/` unit suite (54 tests) also passes.

## Checklist

- [x] Code has been formatted with `pre-commit` (black/isort/flake8 on touched files clean)
- [x] All unit tests are passing
- [x] Docstrings are in Google style
- [x] Related documentation has been updated (`SKILL.md`, cookbook example)
- [x] Code is ready for review